### PR TITLE
v2.0.1: Update GET `/albums/{id}` response

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,8 +453,6 @@ Use this endpoint to get an album.
               }
 ```
 
-> If there are **no songs** in the album, the `songs` property will be not exist in the response body (`undefined`).
-
 #### 3. Edit an album
 
 Use this endpoint to edit an album.

--- a/migrations/1657894593819_create-table-albums.js
+++ b/migrations/1657894593819_create-table-albums.js
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 exports.up = (pgm) => {
   pgm.createTable('albums', {
     id: {

--- a/migrations/1657894872157_create-table-songs.js
+++ b/migrations/1657894872157_create-table-songs.js
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 exports.up = (pgm) => {
   pgm.createTable('songs', {
     id: {

--- a/migrations/1684587064597_create-table-users.js
+++ b/migrations/1684587064597_create-table-users.js
@@ -1,7 +1,3 @@
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
 exports.up = (pgm) => {
   pgm.createTable('users', {
     id: {

--- a/migrations/1684587615841_create-table-authentications.js
+++ b/migrations/1684587615841_create-table-authentications.js
@@ -1,7 +1,3 @@
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
 exports.up = (pgm) => {
   pgm.createTable('authentications', {
     token: {

--- a/migrations/1684654520323_create-table-playlists.js
+++ b/migrations/1684654520323_create-table-playlists.js
@@ -1,7 +1,3 @@
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
 exports.up = (pgm) => {
   pgm.createTable('playlists', {
     id: {

--- a/migrations/1684655798573_add-foreign-key-to-songs.album-id-column.js
+++ b/migrations/1684655798573_add-foreign-key-to-songs.album-id-column.js
@@ -1,7 +1,3 @@
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
 exports.up = (pgm) => {
   pgm.sql("INSERT INTO albums VALUES ('old_songs', 'old_songs', 2023)");
 

--- a/migrations/1684671961499_create-table-playlist-songs.js
+++ b/migrations/1684671961499_create-table-playlist-songs.js
@@ -1,7 +1,3 @@
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
 exports.up = (pgm) => {
   pgm.createTable('playlist_songs', {
     id: {

--- a/migrations/1684712466657_create-table-collaborations.js
+++ b/migrations/1684712466657_create-table-collaborations.js
@@ -1,7 +1,3 @@
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
 exports.up = (pgm) => {
   pgm.createTable('collaborations', {
     id: {

--- a/migrations/1684721272097_create-table-playlist-song-activities.js
+++ b/migrations/1684721272097_create-table-playlist-song-activities.js
@@ -1,7 +1,3 @@
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
 exports.up = (pgm) => {
   pgm.createTable('playlist_song_activities', {
     id: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openmusic-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openmusic-api",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@hapi/hapi": "^20.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmusic-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "API that store free-music playlist to everybody",
   "main": "src/index.js",
   "scripts": {

--- a/src/services/postgres/AlbumsService.js
+++ b/src/services/postgres/AlbumsService.js
@@ -38,7 +38,7 @@ class AlbumsService {
   /**
    * Get an album by id.
    * @param {string} id The album's id.
-   * @returns {Promise<object>} The album.
+   * @returns {Promise<object>} The album with songs.
    * @throws {NotFoundError} if album not found.
    */
   async getAlbumById(id) {
@@ -53,7 +53,8 @@ class AlbumsService {
 
     const album = result.rows[0];
     const songs = await this._songsService.getSongsByAlbumId(id);
-    return (songs.length) ? { ...album, songs } : album;
+
+    return { ...album, songs };
   }
 
   /**


### PR DESCRIPTION
## What changed

- Update GET `/albums/{id}` response: return `songs` with empty array if there are no any songs in the album.
- Remove unused vars & disable linter in migration files.